### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/PremiumFriday/security/code-scanning/1](https://github.com/hsaito/PremiumFriday/security/code-scanning/1)

To fix this issue, explicitly specify a `permissions` block in the workflow file `.github/workflows/dotnet.yml`, ideally at the top level (applies to all jobs unless overridden). The block should set `contents: read`, which is the minimum required for build and test workflows such as this. Insert this block after the workflow `name:` or after the `on:` block (standard practice is after the workflow `name:` for readability). No additional libraries or changes to other files are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
