### PR TITLE
Update Dependabot target branch to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,10 @@ version: 2
 updates:
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "daily"
     assignees:
       - "hsaito"
-
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Change the target branch in the Dependabot configuration from develop to main and add a cooldown period for updates.